### PR TITLE
Add global layout to spaces routes with header

### DIFF
--- a/.ai/implementation.md
+++ b/.ai/implementation.md
@@ -2,6 +2,14 @@
 
 ## Recently Completed
 
+### Spaces Global Layout (follow-up to #65)
+All `/spaces/*` routes now render under the global layout with the navbar visible, matching the dashboard/create/timeline feel.
+
+**New files created:**
+- `app/spaces/layout.tsx` — SpacesLayout with Header; identical pattern to other route layouts
+
+---
+
 ### Family/Group Goal Sharing (#65)
 Added public/private visibility for goals and full shared-spaces infrastructure for collaborative financial planning.
 

--- a/app/spaces/layout.tsx
+++ b/app/spaces/layout.tsx
@@ -1,0 +1,16 @@
+import { Header } from "@/components";
+
+export default function SpacesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col bg-zinc-50 dark:bg-zinc-950">
+      <Header />
+      <main className="flex-1">
+        {children}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a global layout wrapper to all `/spaces/*` routes to display the Header component and maintain consistent styling with other route sections (dashboard, create, timeline).

## Changes
- **New file:** `app/spaces/layout.tsx` — Implements SpacesLayout component that wraps all spaces routes with a flex column layout, Header component, and consistent dark mode styling
- **Updated:** `.ai/implementation.md` — Documents completion of spaces global layout follow-up

## Implementation Details
The new layout follows the established pattern used in other route sections:
- Renders Header component at the top
- Uses flex layout with `min-h-screen` to ensure full viewport height
- Applies consistent background colors (`bg-zinc-50` light / `dark:bg-zinc-950` dark)
- Main content area is flex-1 to fill remaining space

https://claude.ai/code/session_01CK9sFjzeeU6DBXmMhKBZWK