### PR TITLE
feat: add share and edit functionalities to dashboard goal cards

### DIFF
--- a/.ai/components.md
+++ b/.ai/components.md
@@ -14,6 +14,8 @@ Reusable React components that form the application's user interface. Built with
 | `components/ui/Badge.tsx` | Badge and BucketBadge for labels/chips |
 | `components/ui/index.ts` | Barrel export for UI components |
 | `components/Dashboard/SummaryStats.tsx` | Dashboard summary statistics and export actions |
+| `components/Dashboard/EditGoalModal.tsx` | Modal with inline form for editing all goal fields |
+| `components/Dashboard/ShareGoalModal.tsx` | Modal for toggling goal visibility and selecting a space |
 | `components/Dashboard/ExportMenu.tsx` | Print/Export actions dropdown/button |
 | `components/ui/Toast.tsx` | Toast notification system |
 | `components/ui/Tooltip.tsx` | Reusable tooltip component |

--- a/.ai/implementation.md
+++ b/.ai/implementation.md
@@ -104,9 +104,29 @@ Removed the "Sharing" (visibility) step from the goal creation wizard. Goals are
 
 ---
 
+### Goal Share & Edit from Dashboard
+Added edit and share buttons to dashboard goal cards with modal dialogs.
+
+**New files created:**
+- `components/Dashboard/EditGoalModal.tsx` — Inline edit form modal for all goal fields (title, description, amount, currency, date, bucket, why)
+- `components/Dashboard/ShareGoalModal.tsx` — Visibility/sharing modal using `VisibilityToggle` + space selector; auth-gated
+
+**Modified files:**
+- `context/GoalsContext.tsx` — Added `UPDATE_GOAL` reducer action, `updateGoal()` callback (syncs to Supabase for authenticated users), and `updateGoalRemote` import
+- `components/Dashboard/GoalCard.tsx` — Added edit button (pencil icon) and share button (upload icon); both open respective modals
+- `components/Dashboard/index.ts` — Added `EditGoalModal` and `ShareGoalModal` exports
+- `messages/en.json` — Added `common.saving`, `common.share`, `dashboard.editModal.*`, `dashboard.shareModal.*` keys
+- `messages/es.json` — Same keys in Spanish
+
+**Architecture:**
+- `updateGoal(goalId, updates)` — partial update; merges into existing goal; persists to Supabase if authenticated, to localStorage otherwise (via existing effect)
+- Edit modal reuses `Input`, `Textarea`, `Select`, `Label` UI primitives + validation mirrors create-form rules
+- Share modal reuses `VisibilityToggle` and `SpacesContext`; shows auth gate for anonymous users
+
+---
+
 ## Next Steps
 - #68: Personal Data Privacy Consent (Legal Compliance) — should ship alongside auth
-- #53: Edit Goals — add edit button to goal cards
 - #52: Progress Tracking + Savings Calculator
 - #66: Goal-to-Investment Vehicle Linking
 - #67: Currency Exchange Rate Display

--- a/components/Dashboard/EditGoalModal.tsx
+++ b/components/Dashboard/EditGoalModal.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslations } from 'next-intl';
+import { Goal, Bucket, Currency, CURRENCIES, BUCKETS } from '@/types';
+import { useGoals } from '@/context';
+import { useToast } from '@/components/ui';
+import { Button, Input, Textarea, Label, Select, Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui';
+
+interface EditGoalModalProps {
+  goal: Goal;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function EditGoalModal({ goal, isOpen, onClose }: EditGoalModalProps) {
+  const t = useTranslations('dashboard.editModal');
+  const tCommon = useTranslations('common');
+  const tGoalForm = useTranslations('goalForm');
+  const tBuckets = useTranslations('buckets');
+  const { updateGoal } = useGoals();
+  const { showToast } = useToast();
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Form state — initialised from the goal prop
+  const [title, setTitle] = useState(goal.title);
+  const [description, setDescription] = useState(goal.description);
+  const [amount, setAmount] = useState(String(goal.amount));
+  const [currency, setCurrency] = useState<Currency>(goal.currency);
+  const [targetDate, setTargetDate] = useState(
+    goal.targetDate instanceof Date
+      ? goal.targetDate.toISOString().split('T')[0]
+      : String(goal.targetDate).split('T')[0]
+  );
+  const [bucket, setBucket] = useState<Bucket>(goal.bucket);
+  const [whyItMatters, setWhyItMatters] = useState(goal.whyItMatters);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Reset form when goal changes
+  useEffect(() => {
+    setTitle(goal.title);
+    setDescription(goal.description);
+    setAmount(String(goal.amount));
+    setCurrency(goal.currency);
+    setTargetDate(
+      goal.targetDate instanceof Date
+        ? goal.targetDate.toISOString().split('T')[0]
+        : String(goal.targetDate).split('T')[0]
+    );
+    setBucket(goal.bucket);
+    setWhyItMatters(goal.whyItMatters);
+  }, [goal]);
+
+  // Close on Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = '';
+    };
+  }, [isOpen, onClose]);
+
+  // Validation
+  const titleError = title.length > 0 && title.length < 3;
+  const descriptionError = description.length > 0 && description.length < 20;
+  const amountError = amount !== '' && (isNaN(Number(amount)) || Number(amount) <= 0);
+  const dateError = targetDate !== '' && new Date(targetDate) <= new Date(new Date().toDateString());
+  const whyError = whyItMatters.length > 0 && whyItMatters.length < 10;
+
+  const isValid =
+    title.length >= 3 &&
+    description.length >= 20 &&
+    Number(amount) > 0 &&
+    targetDate !== '' &&
+    new Date(targetDate) > new Date(new Date().toDateString()) &&
+    whyItMatters.length >= 10;
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+      onClose();
+    }
+  };
+
+  const handleSave = () => {
+    if (!isValid) return;
+    setIsSaving(true);
+
+    updateGoal(goal.id, {
+      title,
+      description,
+      amount: Number(amount),
+      currency,
+      targetDate: new Date(targetDate),
+      bucket,
+      whyItMatters,
+    });
+
+    showToast(t('savedToast'), 'success');
+    setIsSaving(false);
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  const bucketColors: Record<Bucket, string> = {
+    safety: 'border-green-500 bg-green-50 dark:bg-green-950/30',
+    growth: 'border-blue-500 bg-blue-50 dark:bg-blue-950/30',
+    dream: 'border-purple-500 bg-purple-50 dark:bg-purple-950/30',
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-in fade-in duration-200"
+      onClick={handleBackdropClick}
+      aria-modal="true"
+      role="dialog"
+      aria-labelledby="edit-goal-modal-title"
+    >
+      <div
+        ref={modalRef}
+        className="w-full max-w-lg max-h-[90vh] flex flex-col animate-in zoom-in-95 duration-200"
+      >
+        <Card className="border-border shadow-lg flex flex-col overflow-hidden">
+          {/* Header */}
+          <CardHeader className="flex-shrink-0">
+            <div className="flex items-center justify-between">
+              <CardTitle id="edit-goal-modal-title">{t('title')}</CardTitle>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 transition-colors"
+                aria-label={tCommon('cancel')}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+                </svg>
+              </button>
+            </div>
+          </CardHeader>
+
+          {/* Scrollable body */}
+          <CardContent className="overflow-y-auto flex-1 space-y-5">
+            {/* Title */}
+            <div className="space-y-1.5">
+              <Label htmlFor="edit-title" required>{tGoalForm('step1.titleLabel')}</Label>
+              <Input
+                id="edit-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                error={titleError}
+                maxLength={100}
+                placeholder={tGoalForm('step1.titlePlaceholder')}
+              />
+              {titleError && <p className="text-xs text-red-600">{tGoalForm('step1.titleError')}</p>}
+            </div>
+
+            {/* Description */}
+            <div className="space-y-1.5">
+              <Label htmlFor="edit-description" required>{tGoalForm('step1.descriptionLabel')}</Label>
+              <Textarea
+                id="edit-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                error={descriptionError}
+                rows={3}
+                maxLength={500}
+                placeholder={tGoalForm('step1.descriptionPlaceholder')}
+              />
+              {descriptionError && <p className="text-xs text-red-600">{tGoalForm('step1.descriptionError')}</p>}
+            </div>
+
+            {/* Amount + Currency */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="edit-amount" required>{tGoalForm('step2.amountLabel')}</Label>
+                <Input
+                  id="edit-amount"
+                  type="number"
+                  min="0.01"
+                  step="0.01"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  error={amountError}
+                  placeholder="0.00"
+                />
+                {amountError && <p className="text-xs text-red-600">{tGoalForm('step2.amountError')}</p>}
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="edit-currency">{tGoalForm('step2.currencyLabel')}</Label>
+                <Select
+                  id="edit-currency"
+                  value={currency}
+                  onChange={(e) => setCurrency(e.target.value as Currency)}
+                >
+                  {CURRENCIES.map((c) => (
+                    <option key={c} value={c}>{c}</option>
+                  ))}
+                </Select>
+              </div>
+            </div>
+
+            {/* Target Date */}
+            <div className="space-y-1.5">
+              <Label htmlFor="edit-date" required>{tGoalForm('step3.dateLabel')}</Label>
+              <Input
+                id="edit-date"
+                type="date"
+                value={targetDate}
+                onChange={(e) => setTargetDate(e.target.value)}
+                error={dateError}
+              />
+              {dateError && <p className="text-xs text-red-600">{tGoalForm('step3.dateError')}</p>}
+            </div>
+
+            {/* Bucket */}
+            <div className="space-y-1.5">
+              <Label>{t('bucketLabel')}</Label>
+              <div className="grid grid-cols-3 gap-2">
+                {BUCKETS.map((b) => (
+                  <button
+                    key={b}
+                    type="button"
+                    onClick={() => setBucket(b)}
+                    className={`rounded-lg border-2 p-2 text-center text-xs font-medium transition-all cursor-pointer ${
+                      bucket === b
+                        ? bucketColors[b]
+                        : 'border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 hover:border-zinc-300 dark:hover:border-zinc-600'
+                    }`}
+                  >
+                    {tBuckets(`${b}.name`)}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Why It Matters */}
+            <div className="space-y-1.5">
+              <Label htmlFor="edit-why" required>{tGoalForm('step5.whyLabel')}</Label>
+              <Textarea
+                id="edit-why"
+                value={whyItMatters}
+                onChange={(e) => setWhyItMatters(e.target.value)}
+                error={whyError}
+                rows={3}
+                maxLength={500}
+                placeholder={tGoalForm('step5.whyPlaceholder')}
+              />
+              {whyError && <p className="text-xs text-red-600">{tGoalForm('step5.whyError')}</p>}
+            </div>
+          </CardContent>
+
+          {/* Footer */}
+          <CardFooter className="flex-shrink-0 flex justify-end gap-2 border-t border-border">
+            <Button variant="ghost" onClick={onClose} disabled={isSaving}>
+              {tCommon('cancel')}
+            </Button>
+            <Button onClick={handleSave} disabled={!isValid || isSaving}>
+              {isSaving ? tCommon('saving') : tCommon('save')}
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/components/Dashboard/GoalCard.tsx
+++ b/components/Dashboard/GoalCard.tsx
@@ -5,6 +5,8 @@ import { useTranslations, useLocale } from 'next-intl';
 import { Goal, formatCurrency, formatDate } from '@/types';
 import { useGoals } from '@/context';
 import { useToast, ConfirmationModal } from '@/components/ui';
+import { EditGoalModal } from './EditGoalModal';
+import { ShareGoalModal } from './ShareGoalModal';
 
 interface GoalCardProps extends HTMLAttributes<HTMLDivElement> {
   goal: Goal;
@@ -20,6 +22,8 @@ export const GoalCard = forwardRef<HTMLDivElement, GoalCardProps>(
     const { showToast } = useToast();
     const commonT = useTranslations('common');
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+    const [isShareModalOpen, setIsShareModalOpen] = useState(false);
 
     // Calculate days remaining (simple version, could move to helper)
     const today = new Date();
@@ -64,10 +68,41 @@ export const GoalCard = forwardRef<HTMLDivElement, GoalCardProps>(
             </div>
 
             {/* Priority Badge and Actions */}
-            <div className="flex items-center gap-2">
-              <span className="flex h-6 w-6 items-center justify-center rounded-full bg-zinc-100 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+            <div className="flex items-center gap-1">
+              <span className="flex h-6 w-6 items-center justify-center rounded-full bg-zinc-100 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400 mr-1">
                 #{goal.priority}
               </span>
+
+              {/* Share button */}
+              <button
+                type="button"
+                onClick={() => setIsShareModalOpen(true)}
+                className="rounded p-1 text-zinc-400 hover:bg-blue-50 hover:text-blue-500 dark:hover:bg-blue-900/20 dark:hover:text-blue-400 transition-colors cursor-pointer"
+                aria-label={commonT('share')}
+                title={commonT('share')}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/>
+                  <polyline points="16 6 12 2 8 6"/>
+                  <line x1="12" y1="2" x2="12" y2="15"/>
+                </svg>
+              </button>
+
+              {/* Edit button */}
+              <button
+                type="button"
+                onClick={() => setIsEditModalOpen(true)}
+                className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 transition-colors cursor-pointer"
+                aria-label={commonT('edit')}
+                title={commonT('edit')}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+                </svg>
+              </button>
+
+              {/* Delete button */}
               <button
                 type="button"
                 onClick={handleDeleteClick}
@@ -106,6 +141,7 @@ export const GoalCard = forwardRef<HTMLDivElement, GoalCardProps>(
           </div>
         </div>
 
+        {/* Modals */}
         <ConfirmationModal
           isOpen={isDeleteModalOpen}
           onClose={() => setIsDeleteModalOpen(false)}
@@ -115,6 +151,18 @@ export const GoalCard = forwardRef<HTMLDivElement, GoalCardProps>(
           confirmLabel={commonT('delete')}
           cancelLabel={commonT('cancel')}
           variant="destructive"
+        />
+
+        <EditGoalModal
+          goal={goal}
+          isOpen={isEditModalOpen}
+          onClose={() => setIsEditModalOpen(false)}
+        />
+
+        <ShareGoalModal
+          goal={goal}
+          isOpen={isShareModalOpen}
+          onClose={() => setIsShareModalOpen(false)}
         />
       </>
     );

--- a/components/Dashboard/ShareGoalModal.tsx
+++ b/components/Dashboard/ShareGoalModal.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslations } from 'next-intl';
+import { Goal, GoalVisibility } from '@/types';
+import { useGoals } from '@/context';
+import { useAuth } from '@/context';
+import { useSpaces } from '@/context';
+import { useToast, Button, Card, CardHeader, CardTitle, CardContent, CardFooter, Select, Label } from '@/components/ui';
+import { VisibilityToggle } from '@/components/Spaces/VisibilityToggle';
+
+interface ShareGoalModalProps {
+  goal: Goal;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function ShareGoalModal({ goal, isOpen, onClose }: ShareGoalModalProps) {
+  const t = useTranslations('dashboard.shareModal');
+  const tCommon = useTranslations('common');
+  const tSpaces = useTranslations('spaces');
+  const { updateGoal } = useGoals();
+  const { user } = useAuth();
+  const { spaces } = useSpaces();
+  const { showToast } = useToast();
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  const [visibility, setVisibility] = useState<GoalVisibility>(goal.visibility ?? 'private');
+  const [spaceId, setSpaceId] = useState<string | null>(goal.spaceId ?? null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Reset when goal changes
+  useEffect(() => {
+    setVisibility(goal.visibility ?? 'private');
+    setSpaceId(goal.spaceId ?? null);
+  }, [goal]);
+
+  // Close on Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = '';
+    };
+  }, [isOpen, onClose]);
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+      onClose();
+    }
+  };
+
+  function handleVisibilityChange(v: GoalVisibility) {
+    setVisibility(v);
+    if (v === 'private') {
+      setSpaceId(null);
+    } else if (v === 'shared' && spaceId === null && spaces.length > 0) {
+      setSpaceId(spaces[0].id);
+    }
+  }
+
+  const isValid =
+    visibility === 'private' ||
+    (visibility === 'shared' && (spaceId !== null || spaces.length === 0));
+
+  const handleSave = () => {
+    if (!isValid) return;
+    setIsSaving(true);
+
+    updateGoal(goal.id, { visibility, spaceId });
+
+    showToast(
+      visibility === 'shared' ? t('sharedToast') : t('madePrivateToast'),
+      'success'
+    );
+    setIsSaving(false);
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-in fade-in duration-200"
+      onClick={handleBackdropClick}
+      aria-modal="true"
+      role="dialog"
+      aria-labelledby="share-goal-modal-title"
+    >
+      <div
+        ref={modalRef}
+        className="w-full max-w-md animate-in zoom-in-95 duration-200"
+      >
+        <Card className="border-border shadow-lg">
+          {/* Header */}
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <CardTitle id="share-goal-modal-title">{t('title')}</CardTitle>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 transition-colors"
+                aria-label={tCommon('cancel')}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+                </svg>
+              </button>
+            </div>
+          </CardHeader>
+
+          <CardContent className="space-y-5">
+            {/* Goal name */}
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+              {t('subtitle', { title: goal.title })}
+            </p>
+
+            {/* Auth gate */}
+            {!user ? (
+              <div className="rounded-lg border border-border bg-zinc-50 dark:bg-zinc-900 p-4 flex items-start gap-3">
+                <LockIcon className="w-5 h-5 text-zinc-400 flex-shrink-0 mt-0.5" />
+                <div>
+                  <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                    {tSpaces('signInRequired')}
+                  </p>
+                  <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-0.5">
+                    {tSpaces('signInDescription')}
+                  </p>
+                  <a
+                    href="/auth/login"
+                    className="mt-2 inline-block text-sm font-medium text-primary hover:underline"
+                  >
+                    {tSpaces('signIn')} →
+                  </a>
+                </div>
+              </div>
+            ) : (
+              <>
+                {/* Visibility toggle */}
+                <div className="space-y-2">
+                  <Label>{t('visibilityLabel')}</Label>
+                  <VisibilityToggle value={visibility} onChange={handleVisibilityChange} />
+                </div>
+
+                {/* Option explanation cards */}
+                <div className="grid grid-cols-2 gap-3">
+                  <div className={`rounded-lg border p-3 transition-colors ${visibility === 'private' ? 'border-primary bg-primary/5' : 'border-border bg-background'}`}>
+                    <div className="flex items-center gap-2 mb-1">
+                      <LockIcon className="w-4 h-4 text-zinc-500" />
+                      <span className="text-xs font-medium text-zinc-900 dark:text-zinc-100">{tSpaces('private')}</span>
+                    </div>
+                    <p className="text-xs text-zinc-500 dark:text-zinc-400">{t('privateDesc')}</p>
+                  </div>
+                  <div className={`rounded-lg border p-3 transition-colors ${visibility === 'shared' ? 'border-primary bg-primary/5' : 'border-border bg-background'}`}>
+                    <div className="flex items-center gap-2 mb-1">
+                      <UsersIcon className="w-4 h-4 text-zinc-500" />
+                      <span className="text-xs font-medium text-zinc-900 dark:text-zinc-100">{tSpaces('shared')}</span>
+                    </div>
+                    <p className="text-xs text-zinc-500 dark:text-zinc-400">{t('sharedDesc')}</p>
+                  </div>
+                </div>
+
+                {/* Space selector (only when shared) */}
+                {visibility === 'shared' && (
+                  <div>
+                    {spaces.length === 0 ? (
+                      <div className="rounded-lg border border-dashed border-border bg-zinc-50 dark:bg-zinc-900/50 p-4 text-center">
+                        <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-2">
+                          {t('noSpaces')}
+                        </p>
+                        <a
+                          href="/spaces"
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-sm font-medium text-primary hover:underline"
+                        >
+                          {t('createSpaceLink')}
+                        </a>
+                      </div>
+                    ) : (
+                      <div className="space-y-1.5">
+                        <Label htmlFor="share-space-select">{t('spaceLabel')}</Label>
+                        <Select
+                          id="share-space-select"
+                          value={spaceId ?? ''}
+                          onChange={(e) => setSpaceId(e.target.value || null)}
+                        >
+                          <option value="">{t('selectSpace')}</option>
+                          {spaces.map((s) => (
+                            <option key={s.id} value={s.id}>{s.name}</option>
+                          ))}
+                        </Select>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+          </CardContent>
+
+          {/* Footer */}
+          <CardFooter className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={onClose} disabled={isSaving}>
+              {tCommon('cancel')}
+            </Button>
+            {user && (
+              <Button onClick={handleSave} disabled={!isValid || isSaving}>
+                {isSaving ? tCommon('saving') : tCommon('save')}
+              </Button>
+            )}
+          </CardFooter>
+        </Card>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+// =============================================================================
+// Icon helpers
+// =============================================================================
+
+function LockIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+    </svg>
+  );
+}
+
+function UsersIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+  );
+}

--- a/components/Dashboard/index.ts
+++ b/components/Dashboard/index.ts
@@ -1,5 +1,7 @@
 export * from './BucketSection';
 export * from './GoalCard';
+export * from './EditGoalModal';
+export * from './ShareGoalModal';
 export * from './SortableGoalCard';
 export * from './SummaryStats';
 export * from './ExportMenu';

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,6 +5,7 @@
     "logo": "FinGoal",
     "loading": "Loading...",
     "save": "Save",
+    "saving": "Saving...",
     "cancel": "Cancel",
     "back": "Back",
     "next": "Next",
@@ -12,6 +13,7 @@
     "creating": "Creating...",
     "delete": "Delete",
     "edit": "Edit",
+    "share": "Share",
     "stepIndicator": {
       "stepOf": "Step {current} of {total}",
       "progress": "Form progress: Step {current} of {total}, {label}",
@@ -171,6 +173,24 @@
     "actions": {
       "addGoal": "Add goal",
       "viewTimeline": "View timeline"
+    },
+    "editModal": {
+      "title": "Edit Goal",
+      "bucketLabel": "Bucket",
+      "savedToast": "Goal updated successfully"
+    },
+    "shareModal": {
+      "title": "Share Goal",
+      "subtitle": "Choose who can see \"{title}\"",
+      "visibilityLabel": "Visibility",
+      "privateDesc": "Only you can see this goal.",
+      "sharedDesc": "All members of your chosen space can see this goal.",
+      "spaceLabel": "Share with which space?",
+      "selectSpace": "Select a space…",
+      "noSpaces": "You don't have any shared spaces yet.",
+      "createSpaceLink": "Create a space first →",
+      "sharedToast": "Goal shared successfully",
+      "madePrivateToast": "Goal is now private"
     }
   },
   "buckets": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -5,6 +5,7 @@
     "logo": "FinGoal",
     "loading": "Cargando...",
     "save": "Guardar",
+    "saving": "Guardando...",
     "cancel": "Cancelar",
     "back": "Atrás",
     "next": "Siguiente",
@@ -12,6 +13,7 @@
     "creating": "Creando...",
     "delete": "Eliminar",
     "edit": "Editar",
+    "share": "Compartir",
     "stepIndicator": {
       "stepOf": "Paso {current} de {total}",
       "progress": "Progreso del formulario: Paso {current} de {total}, {label}",
@@ -171,6 +173,24 @@
     "actions": {
       "addGoal": "Agregar objetivo",
       "viewTimeline": "Ver línea de tiempo"
+    },
+    "editModal": {
+      "title": "Editar objetivo",
+      "bucketLabel": "Categoría",
+      "savedToast": "Objetivo actualizado con éxito"
+    },
+    "shareModal": {
+      "title": "Compartir objetivo",
+      "subtitle": "Elige quién puede ver \"{title}\"",
+      "visibilityLabel": "Visibilidad",
+      "privateDesc": "Solo tú puedes ver este objetivo.",
+      "sharedDesc": "Todos los miembros de tu espacio pueden ver este objetivo.",
+      "spaceLabel": "¿Compartir con qué espacio?",
+      "selectSpace": "Selecciona un espacio…",
+      "noSpaces": "Aún no tienes espacios compartidos.",
+      "createSpaceLink": "Crea un espacio primero →",
+      "sharedToast": "Objetivo compartido con éxito",
+      "madePrivateToast": "El objetivo ahora es privado"
     }
   },
   "buckets": {


### PR DESCRIPTION
- Add `updateGoal(goalId, updates)` to GoalsContext with Supabase sync
- New `EditGoalModal`: inline form for editing all goal fields (title,
  description, amount, currency, date, bucket, why it matters) with
  real-time validation mirroring the create wizard rules
- New `ShareGoalModal`: reuses VisibilityToggle + SpacesContext to
  toggle a goal between private/shared and select a target space;
  shows auth gate for anonymous users
- GoalCard gains pencil (edit) and share (upload) icon buttons
- i18n: en.json + es.json updated with saving, share, editModal and
  shareModal translation keys

https://claude.ai/code/session_01MG7wEmpjS9tqaCW6MWW4g1